### PR TITLE
Containerize matching-service

### DIFF
--- a/backend/matching-service/.dockerignore
+++ b/backend/matching-service/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/backend/matching-service/Dockerfile
+++ b/backend/matching-service/Dockerfile
@@ -1,0 +1,17 @@
+# LTS version
+FROM node:18
+
+WORKDIR /usr/src/user
+
+COPY package*.json ./
+
+RUN npm install
+
+# Uncomment following for production
+# RUN npm ci --omit=dev
+
+COPY . .
+
+EXPOSE 8003
+
+CMD ["node", "index.js"]

--- a/backend/user-service/.dockerignore
+++ b/backend/user-service/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,16 @@ services:
     networks:
       - frontend
       - backend
+
+  matching:
+    build: ./backend/matching-service
+    container_name: matching-service
+    restart: unless-stopped
+    ports:
+      - 8003:8003
+    networks:
+      - frontend
+      - backend
     depends_on:
       - question-db
 
@@ -41,6 +51,7 @@ services:
     container_name: user-db
     volumes:
       - user-db-data:/data/db
+      - user-db-data:/data/configdb
     ports:
       - 27001:27017
     networks:
@@ -51,6 +62,8 @@ services:
     container_name: question-db
     volumes:
       - question-db-data:/data/db
+      - question-db-data:/data/configdb
+
     ports:
       - 27002:27017
     networks:


### PR DESCRIPTION
Ports for matching service set up as `8003:8003` as per convention

Added a `Dockerfile` to set up a container for `matching-service`, as well as a `.gitignore`

Fixed the use of name volumes to also contain `/data/configdb` for both db containers to prevent anonymous volumes from being created each time the project is set up with compose