### PR TITLE
Fix the use of `auth_request` in the API gateway using Nginx

### DIFF
--- a/api-gateway/default.conf
+++ b/api-gateway/default.conf
@@ -3,41 +3,74 @@ server {
     resolver    127.0.0.11; # docker default DNS server IP address
 
     location /user {
-        # already handles authentication internally
-
+        # handles authentication internally
         proxy_pass http://user-service:8001/user/;
     }
 
     location /api/auth {
-        # already handles authentication internally
-        proxy_pass http://user-service:8001/api/auth/;
+        # handles authentication internally
+        proxy_pass http://user-service:8001/api/auth;
     }
-    location /api/auth/verifyAdmin {
-        proxy_set_header Authorization "test";
-        proxy_pass_request_body on;
-        proxy_pass_request_headers on;
 
-        proxy_pass http://user-service:8001/api/auth/verifyAdmin;
-    }
     location /api/auth/verify {
+        internal;
+        
+        # handles pre-flight requests for auth_request sub-requests
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' $http_origin always;
+            add_header 'Access-Control-Allow-Methods' 'PUT, PATCH, POST, DELETE' always;
+            add_header 'Access-Control-Allow-Headers' 'Origin, Authorization, Content-Type, Accept, Cookie' always;
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain; charset=utf-8';
+            add_header 'Content-Length' 0;
+            return 200;
+        }
 
         proxy_pass http://user-service:8001/api/auth/verify;
+        
+        # ensures original request body is passed on to route after verification;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Original-URI $request_uri;
+    }
+
+    location /api/auth/verifyAdmin {
+        internal;
+
+        # handles pre-flight requests for auth_request sub-requests
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' $http_origin always;
+            add_header 'Access-Control-Allow-Methods' 'PUT, PATCH, POST, DELETE' always;
+            add_header 'Access-Control-Allow-Headers' 'Origin, Authorization, Content-Type, Accept, Cookie' always;
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain; charset=utf-8';
+            add_header 'Content-Length' 0;
+            return 200;
+        }
+
+        proxy_pass http://user-service:8001/api/auth/verifyAdmin;
+
+        # ensures original request body is passed on to route after verification;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Original-URI $request_uri;
     }
 
     location /question {
         auth_request /api/auth/verify;
+        
         proxy_pass http://question-service:8002/question/;
     }
 
     location /question/auth/ {
-        add_header Cookie $http_cookie;
         auth_request /api/auth/verifyAdmin;
-        #auth_request_set $auth_status $upstream_status;
+
         proxy_pass http://question-service:8002/question/auth/;
     }
 
     location /matching {
         auth_request /api/auth/verify;
+
         proxy_pass http://matching-service:8003/matching/;
     }
 

--- a/api-gateway/default.conf
+++ b/api-gateway/default.conf
@@ -7,12 +7,12 @@ server {
         proxy_pass http://user-service:8001/user/;
     }
 
-    location /api/auth {
+    location /auth {
         # handles authentication internally
-        proxy_pass http://user-service:8001/api/auth;
+        proxy_pass http://user-service:8001/auth;
     }
 
-    location /api/auth/verify {
+    location /auth/verify {
         internal;
         
         # handles pre-flight requests for auth_request sub-requests
@@ -26,7 +26,7 @@ server {
             return 200;
         }
 
-        proxy_pass http://user-service:8001/api/auth/verify;
+        proxy_pass http://user-service:8001/auth/verify;
         
         # ensures original request body is passed on to route after verification;
         proxy_pass_request_body off;
@@ -34,7 +34,7 @@ server {
         proxy_set_header X-Original-URI $request_uri;
     }
 
-    location /api/auth/verifyAdmin {
+    location /auth/verifyAdmin {
         internal;
 
         # handles pre-flight requests for auth_request sub-requests
@@ -57,19 +57,19 @@ server {
     }
 
     location /question {
-        auth_request /api/auth/verify;
+        auth_request /auth/verify;
         
         proxy_pass http://question-service:8002/question/;
     }
 
     location /question/auth/ {
-        auth_request /api/auth/verifyAdmin;
+        auth_request /auth/verifyAdmin;
 
         proxy_pass http://question-service:8002/question/auth/;
     }
 
     location /matching {
-        auth_request /api/auth/verify;
+        auth_request /auth/verify;
 
         proxy_pass http://matching-service:8003/matching/;
     }

--- a/backend/collab-service/index.js
+++ b/backend/collab-service/index.js
@@ -6,7 +6,7 @@ const httpServer = createServer();
 const io = new Server(httpServer, {
   cors: {
     origin: 'http://127.0.0.1:8000',
-    methods: 'GET, HEAD, PUT, PATCH, POST, DELETE',
+    methods: 'PUT, PATCH, POST, DELETE',
     allowedHeaders: 'Origin, Authorization, Content-Type, Accept',
     credentials: true,
     optionsSuccessStatus: 200

--- a/backend/matching-service/index.js
+++ b/backend/matching-service/index.js
@@ -6,7 +6,7 @@ const app = express();
 
 var corsOptions = {
   origin: 'http://127.0.0.1:8000',
-  methods: 'GET, HEAD, PUT, PATCH, POST, DELETE',
+  methods: 'PUT, PATCH, POST, DELETE',
   allowedHeaders: 'Origin, Authorization, Content-Type, Accept, Cookie',
   credentials: true,
   optionsSuccessStatus: 200

--- a/backend/question-service/index.js
+++ b/backend/question-service/index.js
@@ -6,7 +6,7 @@ const app = express();
 
 var corsOptions = {
   origin: 'http://127.0.0.1:8000',
-  methods: 'GET, HEAD, PUT, PATCH, POST, DELETE',
+  methods: 'PUT, PATCH, POST, DELETE',
   allowedHeaders: 'Origin, Authorization, Content-Type, Accept, Cookie',
   credentials: true,
   optionsSuccessStatus: 200

--- a/backend/user-service/index.js
+++ b/backend/user-service/index.js
@@ -6,7 +6,7 @@ var bcrypt = require('bcryptjs');
 
 var corsOptions = {
   origin: 'http://127.0.0.1:8000',
-  methods: 'GET, HEAD, PUT, PATCH, POST, DELETE',
+  methods: 'PUT, PATCH, POST, DELETE',
   allowedHeaders: 'Origin, Authorization, Content-Type, Accept, Cookie',
   credentials: true,
   optionsSuccessStatus: 200,
@@ -25,9 +25,6 @@ app.use(cookieSession({
 app.get("/", (req, res) => {
     res.json({message:"route_message says hi!"});
 });
-
-app.options('/api/auth/verify', cors(corsOptions)); // to enable pre-flight requests for verify
-app.options('/api/auth/verifyAdmin', cors(corsOptions)); // to enable pre-flight requests for verifyAdmin
 
 require('./routes/auth.routes')(app);
 require('./routes/user.routes')(app);
@@ -81,6 +78,8 @@ function initial() {
     }
   });
 
+  // Temporary code for creating an admin
+  // To remove: bcrypt, everything below this comment
   const user = new User({
       username: "admin",
       email: "admin@admin.com",

--- a/backend/user-service/middlewares/authJwt.js
+++ b/backend/user-service/middlewares/authJwt.js
@@ -4,8 +4,10 @@ const db = require("../models/index.js");
 
 verifyToken = (req,res,next) => {
     console.log("Authenticating with verifyToken.")
-    console.log("Request headers:\n" + req.headers);
-    console.log("Request body:\n" + req.body);
+    console.log("Request headers:");
+    console.log(req.headers);
+    console.log("Request body:");
+    console.log(req.body);
     let token = req.session.token || req.headers.cookie; // req.session.token used if called locally from user-service
     if (!token) {
         console.log("No token found.");
@@ -19,6 +21,7 @@ verifyToken = (req,res,next) => {
         if (req.session.token) {
             req.userId = decoded.id; // set userId for delete/update user
         }
+        console.log("Authorization success.");
         return res.status(200).send({ message: "Authorization succeeded." });
     });
 };
@@ -26,11 +29,13 @@ verifyToken = (req,res,next) => {
 
 isAdmin = (req,res,next) => {
     console.log("Authenticating with verifyAdmin.")
-    console.log("Request headers:\n" + req.headers);
-    console.log("Request body:\n" + req.body);
+    console.log("Request headers:");
+    console.log(req.headers);
+    console.log("Request body:");
+    console.log(req.body);
     let token = req.session.token || req.headers.cookie; // req.session.token used if called locally from user-service
     if (!token) {
-        console.log( "No token found." );
+        console.log("No token found.");
         return res.status(403).send({ message: "No token provided." });
     }
     jwt.verify(token, config.secret, (err,decoded) => {
@@ -42,6 +47,7 @@ isAdmin = (req,res,next) => {
             if (!req.session.token) {
                 req.userId = decoded.id;
             }
+            console.log("Admin authorization success.");
             return res.status(200).send({ message: "Admin authorization succeeded." });
         }
         console.log("No admin authorization. Forbidden.");

--- a/backend/user-service/middlewares/authJwt.js
+++ b/backend/user-service/middlewares/authJwt.js
@@ -3,49 +3,49 @@ const config = require("../config/auth.config.js");
 const db = require("../models/index.js");
 
 verifyToken = (req,res,next) => {
-    console.log(req.headers);
-    console.log("hello from verifyToken!");
-    let token = req.body.token || req.session.token; //Uses req.session.token if its called locally from user-service
+    console.log("Authenticating with verifyToken.")
+    console.log("Request headers:\n" + req.headers);
+    console.log("Request body:\n" + req.body);
+    let token = req.session.token || req.headers.cookie; // req.session.token used if called locally from user-service
     if (!token) {
-        return res.status(403).send({message:"No token provided!"});
+        console.log("No token found.");
+        return res.status(403).send({ message: "No token provided." });
     }
     jwt.verify(token, config.secret, (err, decoded) => {
-        if(err) {
-            return res.status(401).send({message:"Authorization Failed!"});
+        if (err) {
+            console.log(err.message);
+            return res.status(401).send({ message: "Authorization failed." });
         }
         if (req.session.token) {
             req.userId = decoded.id; // set userId for delete/update user
-            next();
-            return;
         }
-        return res.status(200).send({message:"Authorized!"});
+        return res.status(200).send({ message: "Authorization succeeded." });
     });
 };
 
 
 isAdmin = (req,res,next) => {
-    console.log(req.headers);
-    console.log("hello from verifyAdmin!");
-    let token = req.body.token || req.session.token; //Uses req.session.token if its called locally from user-service
+    console.log("Authenticating with verifyAdmin.")
+    console.log("Request headers:\n" + req.headers);
+    console.log("Request body:\n" + req.body);
+    let token = req.session.token || req.headers.cookie; // req.session.token used if called locally from user-service
     if (!token) {
-        console.log("no token!");
-        return res.status(403).send({message:"No token provided!"});
+        console.log( "No token found." );
+        return res.status(403).send({ message: "No token provided." });
     }
     jwt.verify(token, config.secret, (err,decoded) => {
-        if(err) {
-            console.log("no verify!");
-            return res.status(401).send({message:"Authorization Failed!"});
+        if (err) {
+            console.log(err.message);
+            return res.status(401).send({ message: "Authorization failed." });
         }
-        if(decoded.isAdmin) {
+        if (decoded.isAdmin) {
             if (!req.session.token) {
                 req.userId = decoded.id;
-                next();
-                return;
             }
-            return res.status(200).send({message:"Authorized!"});
+            return res.status(200).send({ message: "Admin authorization succeeded." });
         }
-        console.log("no admin!");
-        return res.status(403).send({message:"Only admins can do this!"});
+        console.log("No admin authorization. Forbidden.");
+        return res.status(403).send({ message: "Admin authorization needed. Forbidden." });
     });
 };
 

--- a/backend/user-service/routes/auth.routes.js
+++ b/backend/user-service/routes/auth.routes.js
@@ -20,5 +20,5 @@ module.exports = function(app) {
   router.get("/verify", [authJwt.verifyToken]);
   router.get("/verifyAdmin", [authJwt.isAdmin]);
 
-  app.use('/api/auth', router);
+  app.use('/auth', router);
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     container_name: api-gateway
     restart: unless-stopped
     volumes:
-      - ./api-gateway/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./api-gateway/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./api-gateway/nginx.conf:/etc/nginx/nginx.conf
+      - ./api-gateway/default.conf:/etc/nginx/conf.d/default.conf
 
 
     ports:

--- a/frontend/src/app/_helpers/http.interceptor.ts
+++ b/frontend/src/app/_helpers/http.interceptor.ts
@@ -1,27 +1,16 @@
 import { Injectable } from '@angular/core';
 import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor,  HTTP_INTERCEPTORS} from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { StorageService } from '../_services/storage.service';
-
 
 @Injectable()
 export class HttpRequestInterceptor implements HttpInterceptor {
-    constructor(private storageService: StorageService) {}
-    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        req = req.clone({ withCredentials: true });
-        let token: string | null = null;
-        if (this.storageService) {
-            const user = this.storageService.getUser();
-            if (user) {
-                token = user.token;
-            }
-        }
-        if (token) {
-            req = req.clone({ headers: req.headers.set('Authorization', token) });
-        }
+    constructor() {}
+    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {        
+        req = req.clone({
+            withCredentials: true
+        });
         return next.handle(req);
     }
 }
 
 export const httpInterceptorProviders = [{provide: HTTP_INTERCEPTORS, useClass: HttpRequestInterceptor, multi: true}];
-

--- a/frontend/src/app/_services/auth.service.ts
+++ b/frontend/src/app/_services/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-const AUTH_API = 'http://127.0.0.1:8080/api/auth/';
+const API_URL = 'http://127.0.0.1:8080/auth/';
 
 const httpOptions = { headers: new HttpHeaders({ 'Content-Type': 'application/json' }) };
 
@@ -15,21 +15,21 @@ export class AuthService {
 
   login(username: string, password: string): Observable<any> {
     return this.http.post(
-      AUTH_API + 'signin',
+      API_URL + 'signin',
       { username, password }, httpOptions
     );
   }
 
   register(username: string, email: string, password: string): Observable<any> {
     return this.http.post(
-      AUTH_API + 'signup',
+      API_URL + 'signup',
       { username, email, password }, httpOptions
     );
   }
 
   signout(): Observable<any> {
     return this.http.post(
-      AUTH_API + 'signout',
+      API_URL + 'signout',
       {}, httpOptions
     );
   }

--- a/frontend/src/app/_services/question.service.ts
+++ b/frontend/src/app/_services/question.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 const API_URL = "http://127.0.0.1:8080/question/"
-const API_AUTH_URL = "http://127.0.0.1:8080/question/auth/"
+const AUTH_API_URL = "http://127.0.0.1:8080/question/auth/"
 
 const httpOptions = { headers: new HttpHeaders({ 'Content-Type': 'application/json' })};
 
@@ -31,7 +31,7 @@ export class QuestionService {
   saveQuestion(question: any): Observable<any> {
     let newobj = Object.assign({}, question);
     return this.http.post(
-        API_AUTH_URL,
+        AUTH_API_URL,
         newobj,
         httpOptions
     )
@@ -40,7 +40,7 @@ export class QuestionService {
   editQuestion(question: any): Observable<any> {
     let newobj = Object.assign({}, question);
     return this.http.put(
-        API_AUTH_URL + newobj.questionId.toString(),
+        AUTH_API_URL + newobj.questionId.toString(),
         newobj,
         httpOptions
     )
@@ -48,7 +48,7 @@ export class QuestionService {
 
   deleteQuestion(id: number): Observable<any> {
     return this.http.delete(
-        API_AUTH_URL + id.toString(),
+        AUTH_API_URL + id.toString(),
         httpOptions
     )
   }


### PR DESCRIPTION
### Changes
- Protected routes:
  - `/question` (_verify_)
  - `/matching` (_verify_)
  - `/question/auth` (_verifyAdmin_)
- `/auth/verify` sends an auth sub-request to the `auth/verify` path, which uses `verifyToken`
- `/auth/verifyAdmin` sends an auth sub-request to the `auth/verifyAdmin` path, which uses `verifyAdmin`
- preflight requests through the auth sub-requests are now handled explicitly in the routed location
