### PR TITLE
Fix local calls to authJwt

### DIFF
--- a/api-gateway/default.conf
+++ b/api-gateway/default.conf
@@ -48,7 +48,7 @@ server {
             return 200;
         }
 
-        proxy_pass http://user-service:8001/api/auth/verifyAdmin;
+        proxy_pass http://user-service:8001/auth/verifyAdmin;
 
         # ensures original request body is passed on to route after verification;
         proxy_pass_request_body off;

--- a/backend/question-service/controllers/question.controller.js
+++ b/backend/question-service/controllers/question.controller.js
@@ -2,7 +2,6 @@ const db = require('../models');
 const Question = db.questions;
 
 exports.create = (req, res) => {
-  console.log(req);
   if (req.body.constructor === Object && Object.keys(req.body).length === 0) {
     res.status(400).send({message: 'Question details missing.'});
     return;

--- a/backend/user-service/index.js
+++ b/backend/user-service/index.js
@@ -2,7 +2,6 @@ const express = require("express");
 const cors = require("cors");
 const cookieSession = require("cookie-session");
 const app = express();
-var bcrypt = require('bcryptjs');
 
 var corsOptions = {
   origin: 'http://127.0.0.1:8000',
@@ -34,7 +33,6 @@ const db = require("./models");
 const dbConfig = require("./config/db.config.js");
 
 const Role = db.role;
-const User = db.user;
 db.mongoose
   .connect(`mongodb://${dbConfig.HOST}:${dbConfig.PORT}/${dbConfig.DB}`, {
       useNewUrlParser:true,
@@ -77,22 +75,4 @@ function initial() {
       });
     }
   });
-
-  // Temporary code for creating an admin
-  // To remove: bcrypt, everything below this comment
-  const user = new User({
-      username: "admin",
-      email: "admin@admin.com",
-      password: bcrypt.hashSync("admin123", 8)
-  });
-  User.findOne({ username: "admin" }).exec().then((findAdmin) => {
-    if(!findAdmin) {
-      user.save().then((user) => {
-        Role.findOne({ name: "admin" }).then((role) => {
-          user.roles = [role.id];
-          user.save().then(() => {});
-        }).catch((err) => {console.log(err);}) 
-      })
-    }
-  })
 }

--- a/backend/user-service/routes/auth.routes.js
+++ b/backend/user-service/routes/auth.routes.js
@@ -17,8 +17,8 @@ module.exports = function(app) {
 
   router.post("/signin", controller.signin);
   router.post("/signout", controller.signout);
-  router.get("/verify", [authJwt.verifyToken]);
-  router.get("/verifyAdmin", [authJwt.isAdmin]);
+  router.get("/verify", authJwt.verifyToken);
+  router.get("/verifyAdmin", authJwt.isAdmin);
 
   app.use('/auth', router);
 };

--- a/backend/user-service/routes/user.routes.js
+++ b/backend/user-service/routes/user.routes.js
@@ -5,11 +5,11 @@ module.exports = function(app) {
   var router = require("express").Router();
 
   router.get("/all", controller.allAccess);
-  router.get("/user", [authJwt.verifyToken], controller.userBoard);
-  router.get("/admin", [authJwt.isAdmin], controller.adminBoard);
-  router.post("/updateUser", [authJwt.verifyToken], controller.updateUser);
-  router.post("/deleteUser", [authJwt.verifyToken], controller.deleteUser);
-  router.get("/allUsers", [authJwt.isAdmin], controller.findAll);
+  router.get("/user", authJwt.verifyToken, controller.userBoard);
+  router.get("/admin", authJwt.isAdmin, controller.adminBoard);
+  router.post("/updateUser", authJwt.verifyToken, controller.updateUser);
+  router.post("/deleteUser", authJwt.verifyToken, controller.deleteUser);
+  router.get("/allUsers", authJwt.isAdmin, controller.findAll);
 
   app.use('/user', router);
 };


### PR DESCRIPTION
Fixed local calls to authJwt middlware by checking if a header 'x-original-uri' exists, if it does that implies the request is coming from another service through the api gateway, else it's being called locally.

Things removed:
- Some console.log() statements
- The pointless square brackets in user and auth routes
- Code to create a default admin account

To create an admin account:
1. Create an account through the frontend
2. Go to Docker Desktop>Containers>user-db>Exec
3. Run the following commands line by line and replace CREATED_USERNAME with the username of the account you just created.
```
docker exec -it user-db mongosh
use user_db
var adminid = db.roles.findOne({name:'admin'}, {_id:1})._id
db.users.updateOne({ username: 'CREATED_USERNAME' }, { $set: { roles: [adminid] } }) //leave the apostrophes around CREATED_USERNAME
```